### PR TITLE
Add Google Analytics gtag to base template

### DIFF
--- a/web_app/templates/web_app/base.html
+++ b/web_app/templates/web_app/base.html
@@ -4,6 +4,17 @@
 
 <head>
     <meta charset="UTF-8" />
+    {% if not show_debug %}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VYE9LHV7CJ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-VYE9LHV7CJ');
+    </script>
+    {% endif %}
     <title>Torres Yardworks | Houston Landscaping & Construction</title>
     <!-- Favicons -->
     <link rel="icon" href="{% static 'web_app/images/base/logo/tc_favicon.png' %}" sizes="32x32" />


### PR DESCRIPTION
## Summary
- Adds the gtag.js snippet (measurement ID `G-VYE9LHV7CJ`) to `web_app/templates/web_app/base.html` so it loads site-wide.
- Wrapped in `{% if not show_debug %}` (the project's existing `settings.DEBUG`-backed context var) so analytics only fires in production.

## Test plan
- [ ] After deploy, visit the live site and confirm `https://www.googletagmanager.com/gtag/js?id=G-VYE9LHV7CJ` loads in DevTools → Network.
- [ ] Confirm a realtime event shows up in GA4 for `G-VYE9LHV7CJ`.
- [ ] Run locally with `DEBUG=True` and confirm the gtag scripts are NOT present in page source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)