### PR TITLE
Phase 2: email modernization + spam protection

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -22,9 +22,23 @@ CSRF_TRUSTED_ORIGINS=https://torresyardworks.com,https://www.torresyardworks.com
 # Directory where the SQLite database file is stored (inside the container)
 DATABASE_DIR=/app/data
 
-# --- Email (Gmail SMTP) -------------------------------------------------------
-EMAIL_HOST_USER=torresyardworks@gmail.com
-EMAIL_HOST_PASSWORD=change-me-to-app-password
+# --- Email (Resend via django-anymail) ---------------------------------------
+# Resend HTTP API key — generate at https://resend.com/api-keys with Sending
+# Access scope only (NOT Full Access).
+EMAIL_BACKEND=anymail.backends.resend.EmailBackend
+RESEND_API_KEY=change-me-re_XXXXXXXX
+
+# All lead notifications and customer auto-replies use this as From:.
+# Domain must be verified in Resend (SPF + DKIM + Return-Path CNAME).
+DEFAULT_FROM_EMAIL=Torres Yardworks <info@torresyardworks.com>
+
+# Where lead notifications are delivered (owner-facing inbox).
+LEADS_EMAIL=info@torresyardworks.com
+
+# --- Spam protection (Cloudflare Turnstile) ----------------------------------
+# Create a widget at https://dash.cloudflare.com -> Turnstile -> Add Site.
+TURNSTILE_SITE_KEY=change-me-0x4AAAAAAA...
+TURNSTILE_SECRET_KEY=change-me-0x4AAAAAAA...
 
 # --- Security Hardening -------------------------------------------------------
 # These require HTTPS (Caddy handles TLS automatically)

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,9 @@ services:
       - DEBUG=True
       - SECRET_KEY=django-insecure-dev-key-do-not-use-in-production
       - ALLOWED_HOSTS=*
-      - EMAIL_HOST_USER=dev@localhost
-      - EMAIL_HOST_PASSWORD=dev
       - EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+      - DEFAULT_FROM_EMAIL=Torres Yardworks <info@torresyardworks.com>
+      - LEADS_EMAIL=info@torresyardworks.com
+      # Cloudflare Turnstile test keys (always pass). Don't use in prod.
+      - TURNSTILE_SITE_KEY=1x00000000000000000000AA
+      - TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,12 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "django>=5.1",
+    "django-anymail[resend]>=15.0",
     "django-environ>=0.12.0",
     "django-import-export>=4.4.0",
     "django-phonenumber-field>=8.4.0",
+    "django-ratelimit>=4.1.0",
+    "django-turnstile>=0.1.3",
     "et-xmlfile>=2.0.0",
     "gunicorn>=25.0.2",
     "invoke>=2.2.1",

--- a/torres_web/settings.py
+++ b/torres_web/settings.py
@@ -201,6 +201,8 @@ CACHES = {
 }
 
 
+
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 

--- a/torres_web/settings.py
+++ b/torres_web/settings.py
@@ -49,6 +49,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'phonenumber_field',
     'import_export',
+    'anymail',
+    'turnstile',
     'web_app',
 ]
 
@@ -161,15 +163,42 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
 
-# Send Email
+# Send Email — Anymail HTTP API (Resend) in prod, console in dev.
+# Dev override happens via EMAIL_BACKEND env var in compose.yaml.
 
-EMAIL_BACKEND = env('EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = env('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
-EMAIL_USE_TLS = True
-EMAIL_USE_SSL = False
+EMAIL_BACKEND = env(
+    'EMAIL_BACKEND',
+    default='django.core.mail.backends.console.EmailBackend',
+)
+DEFAULT_FROM_EMAIL = env(
+    'DEFAULT_FROM_EMAIL',
+    default='Torres Yardworks <info@torresyardworks.com>',
+)
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
+LEADS_EMAIL = env('LEADS_EMAIL', default='info@torresyardworks.com')
+
+ANYMAIL = {
+    'RESEND_API_KEY': env('RESEND_API_KEY', default=''),
+}
+
+# Cloudflare Turnstile — defaults are Cloudflare's documented test keys,
+# which always pass and only work for testing. Override in .env.prod.
+TURNSTILE_SITEKEY = env(
+    'TURNSTILE_SITE_KEY', default='1x00000000000000000000AA',
+)
+TURNSTILE_SECRET = env(
+    'TURNSTILE_SECRET_KEY',
+    default='1x0000000000000000000000000000000AA',
+)
+
+# django-ratelimit cache — LocMemCache is per-process, fine for our
+# single-Gunicorn-worker deployment. Revisit when scaling out.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'torres-default',
+    },
+}
 
 
 # Default primary key field type

--- a/uv.lock
+++ b/uv.lock
@@ -373,6 +373,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "diff-match-patch"
 version = "20241021"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +437,27 @@ wheels = [
 ]
 
 [[package]]
+name = "django-anymail"
+version = "15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "idna" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/43/f0aadb31f2c58afcd9f001f4291998cbd6d289898167e79d908506fc6faf/django_anymail-15.0.tar.gz", hash = "sha256:23d8ab6589afe8cc1ae7665c26879814ad192f4c3ed837a2a1868b0a056869e0", size = 106985, upload-time = "2026-04-18T20:44:19.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/d1/daae99ec3b30886010a499975880ec20c32c622bee6b92c226b715e42f0c/django_anymail-15.0-py3-none-any.whl", hash = "sha256:64d33dd1084bfc8e4e12245f56629be40aa0b0498fc7fc7544d87b9b2048be1e", size = 147229, upload-time = "2026-04-18T20:44:17.323Z" },
+]
+
+[package.optional-dependencies]
+resend = [
+    { name = "svix" },
+]
+
+[[package]]
 name = "django-environ"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -459,6 +492,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/bf/8aa60c9834773b955dff1ddea842e361e8daaf6b0945d5bfc29fc66d53ab/django_phonenumber_field-8.4.0.tar.gz", hash = "sha256:2b83e843dac35eec6a69880a166487235b737a71a1e38c9a52e5ad67d6996083", size = 45512, upload-time = "2025-11-24T15:09:51.904Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/a3/f6b85a9246e22cf719752ad83f5e95aa9ba12419b2f9eff70f20d30e55df/django_phonenumber_field-8.4.0-py3-none-any.whl", hash = "sha256:7a1cb3a6456edb54d879f11ffa0acb227ded08c93b587035d0f28093f0e46511", size = 69528, upload-time = "2025-11-24T15:09:45.479Z" },
+]
+
+[[package]]
+name = "django-ratelimit"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/8f/94038fe739b095aca3e4708ecc8a4e77f1fcfd87bed5d6baff43d4c80bc4/django-ratelimit-4.1.0.tar.gz", hash = "sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b", size = 11551, upload-time = "2023-07-24T20:34:32.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/78/2c59b30cd8bc8068d02349acb6aeed5c4e05eb01cdf2107ccd76f2e81487/django_ratelimit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92", size = 11608, upload-time = "2023-07-24T20:34:31.362Z" },
+]
+
+[[package]]
+name = "django-turnstile"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/e5/795fc00bae0bdbf8fd72d3baa3b700174481ddd7096ba06ee4a7c1fed0af/django_turnstile-0.1.3.tar.gz", hash = "sha256:5079eb937938ba9a475c1a80c146fe1e71de025f25f3e572a911ae926bd5120d", size = 5662, upload-time = "2026-01-18T09:18:12.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/6f/8d4d5cd527d0cd42a894d51ce750dc3bae50a6cbed8294cfc870d119502a/django_turnstile-0.1.3-py3-none-any.whl", hash = "sha256:f7c82b020d5bd0fcaccb2ffac089809afb220671595c55a46a987283d7d5e61b", size = 7011, upload-time = "2026-01-18T09:18:11.486Z" },
 ]
 
 [[package]]
@@ -1697,6 +1748,20 @@ wheels = [
 ]
 
 [[package]]
+name = "standardwebhooks"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d3ddae90953d8f878dc5fd21ba29c02fc9e97e10703f/standardwebhooks-1.0.1.tar.gz", hash = "sha256:b557bb2e4b16ada179a517ec0fe6cbec5acf976c5619922bf29c457f89a451bd", size = 5103, upload-time = "2026-02-18T19:13:06.793Z" }
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,6 +1772,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "svix"
+version = "1.93.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "standardwebhooks" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/49/6a2d5121e8df9eb74519d8106f74852fde18b2105774a43c7fdb45e07c3f/svix-1.93.0.tar.gz", hash = "sha256:31452c4ca43956dcf978fdba62f6ade06e5f5d1dc0d545a53ac18dd0577c1f9e", size = 60886, upload-time = "2026-05-07T11:18:52.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/64/5276ccdc306ea56cfa93901bac04670458909b272fb6d39be4c7b903e652/svix-1.93.0-py3-none-any.whl", hash = "sha256:ba7832f52569335f736d4c61b4d7b6b475ceb304e849697c4345ff0d23a21ba2", size = 136421, upload-time = "2026-05-07T11:18:50.866Z" },
 ]
 
 [[package]]
@@ -1725,9 +1809,12 @@ source = { virtual = "." }
 dependencies = [
     { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django-anymail", extra = ["resend"] },
     { name = "django-environ" },
     { name = "django-import-export" },
     { name = "django-phonenumber-field" },
+    { name = "django-ratelimit" },
+    { name = "django-turnstile" },
     { name = "et-xmlfile" },
     { name = "gunicorn" },
     { name = "invoke" },
@@ -1743,9 +1830,12 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.1" },
+    { name = "django-anymail", extras = ["resend"], specifier = ">=15.0" },
     { name = "django-environ", specifier = ">=0.12.0" },
     { name = "django-import-export", specifier = ">=4.4.0" },
     { name = "django-phonenumber-field", specifier = ">=8.4.0" },
+    { name = "django-ratelimit", specifier = ">=4.1.0" },
+    { name = "django-turnstile", specifier = ">=0.1.3" },
     { name = "et-xmlfile", specifier = ">=2.0.0" },
     { name = "gunicorn", specifier = ">=25.0.2" },
     { name = "invoke", specifier = ">=2.2.1" },
@@ -1771,6 +1861,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
+]
+
+[[package]]
+name = "types-deprecated"
+version = "1.3.1.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3e/9cd21c9292ea64682f1533d315d429c7e35617e168fd54b90e22d530178c/types_deprecated-1.3.1.20260508.tar.gz", hash = "sha256:a03c378da8fd83e2d5715fcdab204cfed1cfccf09766163390333684bb8413c8", size = 8566, upload-time = "2026-05-08T04:46:13.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9f/d05eefc9d26aa2aa2d07f3cde9a909b569370324acfd8403ff7bee466419/types_deprecated-1.3.1.20260508-py3-none-any.whl", hash = "sha256:02de536e9a57fc5fdff09ecfdaae3099a000764597ec4c03b343db4f09adbb37", size = 9059, upload-time = "2026-05-08T04:46:12.686Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
 ]
 
 [[package]]
@@ -1882,6 +1990,81 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/web_app/emails.py
+++ b/web_app/emails.py
@@ -1,0 +1,111 @@
+"""Email helpers for the lead-form pipeline.
+
+Two messages go out per submission:
+
+* ``send_lead_notification`` — owner-facing alert delivered to ``LEADS_EMAIL``.
+  ``Reply-To`` is the customer so hitting reply in the inbox goes straight
+  back to the customer.
+
+* ``send_lead_autoreply`` — customer-facing acknowledgement. ``Reply-To`` is
+  ``LEADS_EMAIL`` so the customer's reply lands in the team inbox.
+
+Both messages route through ``EMAIL_BACKEND`` (Resend in prod via
+``django-anymail``, console backend in dev). Templates live under
+``web_app/templates/web_app/emails/`` with ``.txt`` + ``.html`` companions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
+
+
+@dataclass(frozen=True)
+class LeadContext:
+    """Subset of fields rendered into both email templates.
+
+    Built from a ``ClientLeads`` instance plus the form name. Keeping this
+    a plain dataclass (not the model) keeps the templates decoupled from
+    model internals and makes unit-testing trivial.
+    """
+
+    form_name: str  # 'Quick Estimate', 'Contact', or 'Free Quote'
+    first_name: str
+    last_name: str
+    email: str
+    phone: str
+    address: str
+    date: str
+    service: str
+    subject: str
+    message: str
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}".strip()
+
+
+def context_from_lead(lead, form_name: str) -> LeadContext:
+    """Build a ``LeadContext`` from a saved ``ClientLeads`` instance."""
+    return LeadContext(
+        form_name=form_name,
+        first_name=lead.first_name or '',
+        last_name=lead.last_name or '',
+        email=lead.email or '',
+        phone=lead.phone or '',
+        address=lead.address or '',
+        date=lead.date or '',
+        service=lead.service or '',
+        subject=lead.subject or '',
+        message=lead.message or '',
+    )
+
+
+def _send(
+    *,
+    subject: str,
+    template_base: str,
+    to: list[str],
+    reply_to: list[str],
+    context: LeadContext,
+) -> None:
+    body_txt = render_to_string(f'web_app/emails/{template_base}.txt', {'lead': context})
+    body_html = render_to_string(f'web_app/emails/{template_base}.html', {'lead': context})
+    msg = EmailMultiAlternatives(
+        subject=subject,
+        body=body_txt,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=to,
+        reply_to=reply_to,
+    )
+    msg.attach_alternative(body_html, 'text/html')
+    msg.send(fail_silently=False)
+
+
+def send_lead_notification(lead, form_name: str) -> None:
+    """Notify the team about a new lead. Owner-facing."""
+    ctx = context_from_lead(lead, form_name)
+    subject = f"[{form_name}] New lead from {ctx.full_name or ctx.email}"
+    _send(
+        subject=subject,
+        template_base='lead_notification',
+        to=[settings.LEADS_EMAIL],
+        reply_to=[ctx.email] if ctx.email else [],
+        context=ctx,
+    )
+
+
+def send_lead_autoreply(lead, form_name: str) -> None:
+    """Acknowledge to the customer that we received their message."""
+    ctx = context_from_lead(lead, form_name)
+    subject = "Thanks for contacting Torres Yardworks"
+    _send(
+        subject=subject,
+        template_base='lead_autoreply',
+        to=[ctx.email],
+        reply_to=[settings.LEADS_EMAIL],
+        context=ctx,
+    )

--- a/web_app/forms.py
+++ b/web_app/forms.py
@@ -1,7 +1,111 @@
-from django import forms
-from .models import ClientLeads
+"""Lead-capture forms.
 
-class ReqForm(forms.ModelForm):
+Three public forms, all ``ModelForm`` subclasses backed by ``ClientLeads``.
+Common machinery (honeypot, Cloudflare Turnstile, name-splitting) lives on
+``LeadFormBase``; the subclasses only declare which model fields each page
+collects.
+
+Honeypot: a hidden ``website`` field. Bots fill every input they see; real
+users never touch a CSS-hidden one. Non-empty value → form invalid.
+
+Turnstile: ``django-turnstile``'s ``TurnstileField`` performs the
+server-side siteverify call against Cloudflare. In tests the network call
+is disabled by setting ``TURNSTILE_ENABLE = False`` (see tests/__init__.py).
+"""
+
+from __future__ import annotations
+
+from django import forms
+
+from turnstile.fields import TurnstileField
+
+from web_app.models import ClientLeads
+
+
+class HoneypotMixin:
+    """Adds a hidden ``website`` field. Bots fill it; humans don't."""
+
+    def clean_website(self):
+        if self.cleaned_data.get('website'):
+            # Generic message — don't tip off the bot which field tripped it.
+            raise forms.ValidationError('Submission rejected.')
+        return ''
+
+
+class LeadFormBase(HoneypotMixin, forms.ModelForm):
+    website = forms.CharField(
+        required=False,
+        widget=forms.HiddenInput(attrs={
+            'autocomplete': 'off',
+            'tabindex': '-1',
+            # CSS-hidden via inline style as a belt-and-braces fallback if
+            # the global stylesheet doesn't already hide HiddenInput.
+            'style': 'position:absolute;left:-9999px;',
+            'aria-hidden': 'true',
+        }),
+        label='',
+    )
+    captcha = TurnstileField()
+
     class Meta:
         model = ClientLeads
-        fields = ("first_name", "last_name", "email", "phone", "address", "date", "service", "message")
+        fields: list[str] = []  # subclasses must override
+
+    def __init__(self, *args, remote_ip: str | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Pass the client IP to TurnstileField so siteverify includes it.
+        self.fields['captcha'].remote_ip = remote_ip
+
+
+# ---------------------------------------------------------------------------
+# Forms that collect a single "Name" field (Home quick form, Contact page)
+# ---------------------------------------------------------------------------
+
+
+class _SingleNameLeadForm(LeadFormBase):
+    """Helper base for forms that collect one ``name`` input.
+
+    On save the name is split on the first space — 'Jane Doe' becomes
+    first='Jane', last='Doe', while 'Cher' becomes first='Cher', last=''.
+    """
+
+    name = forms.CharField(max_length=200, label='Name')
+
+    class Meta(LeadFormBase.Meta):
+        fields: list[str] = []  # subclasses set this
+
+    def save(self, commit: bool = True):
+        instance: ClientLeads = super().save(commit=False)
+        name = (self.cleaned_data.get('name') or '').strip()
+        if ' ' in name:
+            first, last = name.split(' ', 1)
+        else:
+            first, last = name, ''
+        instance.first_name = first
+        instance.last_name = last
+        if commit:
+            instance.save()
+        return instance
+
+
+class HomeQuickForm(_SingleNameLeadForm):
+    class Meta(_SingleNameLeadForm.Meta):
+        fields = ['email', 'phone', 'service', 'message']
+
+
+class ContactForm(_SingleNameLeadForm):
+    class Meta(_SingleNameLeadForm.Meta):
+        fields = ['email', 'subject', 'message']
+
+
+# ---------------------------------------------------------------------------
+# Free quote — full split first/last + address + date
+# ---------------------------------------------------------------------------
+
+
+class FreeQuoteForm(LeadFormBase):
+    class Meta(LeadFormBase.Meta):
+        fields = [
+            'first_name', 'last_name', 'email', 'phone',
+            'address', 'date', 'service', 'message',
+        ]

--- a/web_app/templates/web_app/base.html
+++ b/web_app/templates/web_app/base.html
@@ -177,8 +177,8 @@
                         <a href="tel:8329713599">
                             <li class="ftr_phn_icon ftr_call_txt">(832) 971-3599</li>
                         </a>
-                        <a href="mailto: torresyardworks@gmail.com">
-                            <li class="ftr_msg_icon">torresyardworks@gmail.com</li>
+                        <a href="mailto:info@torresyardworks.com">
+                            <li class="ftr_msg_icon">info@torresyardworks.com</li>
                         </a>
                         <li class="ftr_clock_icon">Monday - Friday : <br> 8:00 am - 5:00 pm</li>
                     </ul>

--- a/web_app/templates/web_app/contact.html
+++ b/web_app/templates/web_app/contact.html
@@ -31,7 +31,20 @@
           <div class="col-lg-8 col-md-7 col-sm-12 col-xs-12">
             <form id="contact-form" method="post">
               {% csrf_token %}
-              <div class="messages"></div>
+              {{ form.website }}
+              <div class="messages">
+                {% if form.errors %}
+                  <div class="alert alert-danger">
+                    <strong>Please fix the errors below.</strong>
+                    {{ form.non_field_errors }}
+                    {% for field in form %}
+                      {% for error in field.errors %}
+                        <div>{{ field.label|default:field.name }}: {{ error }}</div>
+                      {% endfor %}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
               <div class="row">
                 <div class="col-md-12">
                   <div class="form-group">
@@ -57,6 +70,9 @@
                     <textarea id="message" name="message" type="text" rows="4" placeholder="Message" class="form-control contact_textarea"></textarea>
                   </div>
                 </div>
+                <div class="col-md-12" style="margin-bottom: 16px;">
+                  {{ form.captcha }}
+                </div>
                 <div class="col-md-12">
                   <input type="submit" value="submit now" class="btn submit_now">
                 </div>
@@ -69,9 +85,9 @@
                 <li class="cnt_map_icon">
                   <p>Katy, Texas</p>
                 </li>
-                <a href="mailto: torresyardworks@gmail.com">
+                <a href="mailto:info@torresyardworks.com">
                   <li class="cnt_mail_icon">
-                    <p class="cnt_fnt_14">torresyardworks@gmail.com</p>
+                    <p class="cnt_fnt_14">info@torresyardworks.com</p>
                   </li>
                 </a>
                 <a href="tel:8329713599">

--- a/web_app/templates/web_app/emails/lead_autoreply.html
+++ b/web_app/templates/web_app/emails/lead_autoreply.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<body style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#222;line-height:1.6;max-width:560px;margin:0 auto;padding:24px;">
+  <p style="margin:0 0 16px;">Hi {{ lead.first_name|default:"there" }},</p>
+
+  <p style="margin:0 0 16px;">Thanks for reaching out to <strong>Torres Yardworks</strong>. We received your {{ lead.form_name|lower }} submission and someone from our team will follow up within one business day.</p>
+
+  <p style="margin:0 0 8px;color:#555;">For reference, here's what you sent:</p>
+  <div style="padding:12px 16px;background:#fafafa;border-left:3px solid #2c8a3e;white-space:pre-wrap;margin-bottom:16px;">{{ lead.message|default:"(no message)" }}</div>
+
+  <p style="margin:0 0 16px;">If anything's urgent, you can reply to this email or call us — we're happy to talk through your project.</p>
+
+  <p style="margin:24px 0 0;color:#555;">— The Torres Yardworks team<br>
+  Houston, TX<br>
+  <a href="mailto:info@torresyardworks.com">info@torresyardworks.com</a></p>
+</body>
+</html>

--- a/web_app/templates/web_app/emails/lead_autoreply.txt
+++ b/web_app/templates/web_app/emails/lead_autoreply.txt
@@ -1,0 +1,13 @@
+Hi {{ lead.first_name|default:"there" }},
+
+Thanks for reaching out to Torres Yardworks. We received your {{ lead.form_name|lower }} submission and someone from our team will follow up within one business day.
+
+For reference, here's what you sent:
+
+{{ lead.message|default:"(no message)" }}
+
+If anything's urgent, you can reply to this email or call us — we're happy to talk through your project.
+
+— The Torres Yardworks team
+Houston, TX
+info@torresyardworks.com

--- a/web_app/templates/web_app/emails/lead_notification.html
+++ b/web_app/templates/web_app/emails/lead_notification.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<body style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#222;line-height:1.5;max-width:640px;margin:0 auto;padding:24px;">
+  <h2 style="margin:0 0 16px;">New {{ lead.form_name }} submission</h2>
+  <p style="margin:0 0 24px;color:#555;">A new lead just came in via torresyardworks.com.</p>
+
+  <table style="border-collapse:collapse;width:100%;margin-bottom:24px;">
+    <tbody>
+      <tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;width:120px;">Name</td><td style="padding:6px 12px;">{{ lead.full_name|default:"(not provided)" }}</td></tr>
+      <tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Email</td><td style="padding:6px 12px;"><a href="mailto:{{ lead.email }}">{{ lead.email|default:"(not provided)" }}</a></td></tr>
+      {% if lead.phone %}<tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Phone</td><td style="padding:6px 12px;">{{ lead.phone }}</td></tr>{% endif %}
+      {% if lead.address %}<tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Address</td><td style="padding:6px 12px;">{{ lead.address }}</td></tr>{% endif %}
+      {% if lead.date %}<tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Date</td><td style="padding:6px 12px;">{{ lead.date }}</td></tr>{% endif %}
+      {% if lead.service %}<tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Service</td><td style="padding:6px 12px;">{{ lead.service }}</td></tr>{% endif %}
+      {% if lead.subject %}<tr><td style="padding:6px 12px;background:#f4f4f4;font-weight:600;">Subject</td><td style="padding:6px 12px;">{{ lead.subject }}</td></tr>{% endif %}
+    </tbody>
+  </table>
+
+  <h3 style="margin:0 0 8px;">Message</h3>
+  <div style="padding:12px 16px;background:#fafafa;border-left:3px solid #2c8a3e;white-space:pre-wrap;">{{ lead.message|default:"(no message)" }}</div>
+
+  <p style="margin-top:24px;color:#888;font-size:13px;">Reply to this email to respond directly to the customer.</p>
+</body>
+</html>

--- a/web_app/templates/web_app/emails/lead_notification.txt
+++ b/web_app/templates/web_app/emails/lead_notification.txt
@@ -1,0 +1,15 @@
+New {{ lead.form_name }} submission on torresyardworks.com
+
+Name:    {{ lead.full_name|default:"(not provided)" }}
+Email:   {{ lead.email|default:"(not provided)" }}
+{% if lead.phone %}Phone:   {{ lead.phone }}
+{% endif %}{% if lead.address %}Address: {{ lead.address }}
+{% endif %}{% if lead.date %}Date:    {{ lead.date }}
+{% endif %}{% if lead.service %}Service: {{ lead.service }}
+{% endif %}{% if lead.subject %}Subject: {{ lead.subject }}
+{% endif %}
+Message:
+{{ lead.message|default:"(no message)" }}
+
+---
+Reply to this email to respond directly to the customer.

--- a/web_app/templates/web_app/index.html
+++ b/web_app/templates/web_app/index.html
@@ -227,7 +227,20 @@
           <h3>FREE ESTIMATE</h3>
           <form id="contact-form" method="post">
             {% csrf_token %}
-            <div class="messages"></div>
+            {{ form.website }}
+            <div class="messages">
+              {% if form.errors %}
+                <div class="alert alert-danger">
+                  <strong>Please fix the errors below.</strong>
+                  {{ form.non_field_errors }}
+                  {% for field in form %}
+                    {% for error in field.errors %}
+                      <div>{{ field.label|default:field.name }}: {{ error }}</div>
+                    {% endfor %}
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
             <div class="row">
               <div class="col-md-6">
                 <div class="form-group request_Form_group">
@@ -274,6 +287,9 @@
                     class="form-control request_form_input height_141"></textarea>
                   <div class="help-block with-errors"></div>
                 </div>
+              </div>
+              <div class="col-md-12" style="margin-bottom: 16px;">
+                {{ form.captcha }}
               </div>
               <div class="col-md-12">
                 <input type="submit" value="Send" class="btn send_btn" />

--- a/web_app/templates/web_app/rate_limited.html
+++ b/web_app/templates/web_app/rate_limited.html
@@ -1,0 +1,11 @@
+{% extends 'web_app/base.html' %}
+{% block content %}
+<div class="wdt_100 pad_94_100 text-center">
+  <div class="container">
+    <h2>Whoa, slow down!</h2>
+    <p>You've sent quite a few messages in a short time. Please wait an hour and try again.</p>
+    <p>If this is urgent, call us directly at <a href="tel:8329713599">(832) 971-3599</a>
+       or email <a href="mailto:info@torresyardworks.com">info@torresyardworks.com</a>.</p>
+  </div>
+</div>
+{% endblock %}

--- a/web_app/templates/web_app/request_quote.html
+++ b/web_app/templates/web_app/request_quote.html
@@ -32,7 +32,20 @@
               </p>
             <form id="contact-form" method="post">
               {% csrf_token %}
-              <div class="messages"></div>
+              {{ form.website }}
+              <div class="messages">
+                {% if form.errors %}
+                  <div class="alert alert-danger">
+                    <strong>Please fix the errors below.</strong>
+                    {{ form.non_field_errors }}
+                    {% for field in form %}
+                      {% for error in field.errors %}
+                        <div>{{ field.label|default:field.name }}: {{ error }}</div>
+                      {% endfor %}
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
               <div class="row">
                 <div class="col-md-6">
                   <div class="form-group">
@@ -99,6 +112,9 @@
                     <textarea id="message_req" name="message" placeholder="Message" rows="4" class="form-control quick_form_control form_message he_224"></textarea>
                     <div class="help-block with-errors"></div>
                   </div>
+                </div>
+                <div class="col-md-12" style="margin-bottom: 16px;">
+                  {{ form.captcha }}
                 </div>
                 <div class="col-md-12">
                   <input type="submit" value="submit now" class="btn submit_now">

--- a/web_app/templates/web_app/thank_you.html
+++ b/web_app/templates/web_app/thank_you.html
@@ -40,7 +40,7 @@
             </h3>
             <div class="stop_buttons">
                 <a href="{% url 'home' %}" class="view-all hvr-bounce-to-right slide_contact_btn slide_service_btn flnone margin_rght">Home</a>
-                <a href="{% url 'gallery' %}" class="view-all hvr-bounce-to-right slide_contact_btn flnone">Gallery</a>
+                {% if show_debug %}<a href="{% url 'gallery' %}" class="view-all hvr-bounce-to-right slide_contact_btn flnone">Gallery</a>{% endif %}
             </div>
         </div>
     </div>

--- a/web_app/tests.py
+++ b/web_app/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/web_app/tests/__init__.py
+++ b/web_app/tests/__init__.py
@@ -1,0 +1,13 @@
+"""Test package.
+
+Disable the django-turnstile network call for the entire test run. The
+module-level ``ENABLE`` flag is captured at import time so ``override_settings``
+in individual tests doesn't reach it — patching here ensures every TestCase
+sees a quiet, offline TurnstileField.
+"""
+
+import turnstile.fields as _turnstile_fields
+import turnstile.widgets as _turnstile_widgets
+
+_turnstile_fields.ENABLE = False
+_turnstile_widgets.ENABLE = False

--- a/web_app/tests/test_emails.py
+++ b/web_app/tests/test_emails.py
@@ -1,0 +1,76 @@
+"""Tests for the lead-email helpers in ``web_app/emails.py``.
+
+Uses Django's locmem email backend (the default under ``TestCase``) so
+sends end up in ``django.core.mail.outbox`` instead of going to Resend.
+"""
+
+from django.core import mail
+from django.test import TestCase
+
+from web_app.emails import send_lead_autoreply, send_lead_notification
+from web_app.models import ClientLeads
+
+
+def _make_lead(**overrides) -> ClientLeads:
+    defaults = dict(
+        first_name='Jane',
+        last_name='Doe',
+        email='jane@example.com',
+        phone='555-0100',
+        address='',
+        date='',
+        service='Lawn & Garden Care',
+        subject='',
+        message='Hi, please call me about my front yard.',
+    )
+    defaults.update(overrides)
+    return ClientLeads.objects.create(**defaults)
+
+
+class SendLeadNotificationTests(TestCase):
+    def test_sends_owner_notification_with_customer_reply_to(self):
+        lead = _make_lead()
+        send_lead_notification(lead, form_name='Contact')
+
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        self.assertEqual(msg.to, ['info@torresyardworks.com'])
+        self.assertEqual(msg.reply_to, ['jane@example.com'])
+        self.assertEqual(msg.from_email, 'Torres Yardworks <info@torresyardworks.com>')
+        self.assertIn('[Contact]', msg.subject)
+        self.assertIn('Jane Doe', msg.subject)
+        self.assertIn('Hi, please call me', msg.body)
+
+    def test_includes_html_alternative(self):
+        send_lead_notification(_make_lead(), form_name='Contact')
+        msg = mail.outbox[0]
+        html_parts = [a for a in msg.alternatives if a[1] == 'text/html']
+        self.assertEqual(len(html_parts), 1)
+        self.assertIn('Jane Doe', html_parts[0][0])
+
+    def test_missing_email_skips_reply_to(self):
+        # An incomplete lead (no email) shouldn't crash — Reply-To just drops.
+        lead = _make_lead(email='')
+        send_lead_notification(lead, form_name='Quick Estimate')
+        self.assertEqual(mail.outbox[0].reply_to, [])
+
+
+class SendLeadAutoreplyTests(TestCase):
+    def test_sends_to_customer_with_team_reply_to(self):
+        lead = _make_lead()
+        send_lead_autoreply(lead, form_name='Quick Estimate')
+
+        msg = mail.outbox[0]
+        self.assertEqual(msg.to, ['jane@example.com'])
+        self.assertEqual(msg.reply_to, ['info@torresyardworks.com'])
+        self.assertEqual(msg.from_email, 'Torres Yardworks <info@torresyardworks.com>')
+        self.assertIn('Thanks for contacting', msg.subject)
+        self.assertIn('Jane', msg.body)
+        # Form-name is lowercased into the body sentence
+        self.assertIn('quick estimate', msg.body.lower())
+
+    def test_includes_html_alternative(self):
+        send_lead_autoreply(_make_lead(), form_name='Free Quote')
+        msg = mail.outbox[0]
+        self.assertEqual(len(msg.alternatives), 1)
+        self.assertEqual(msg.alternatives[0][1], 'text/html')

--- a/web_app/tests/test_forms.py
+++ b/web_app/tests/test_forms.py
@@ -1,0 +1,118 @@
+"""Tests for the lead-capture forms."""
+
+from django.test import TestCase
+
+from web_app.forms import ContactForm, FreeQuoteForm, HomeQuickForm
+from web_app.models import ClientLeads
+
+
+def _valid_quick_form_data(**overrides):
+    data = {
+        'name': 'Jane Doe',
+        'email': 'jane@example.com',
+        'phone': '555-0100',
+        'service': 'Lawn & Garden Care',
+        'message': 'Please come look at my lawn.',
+    }
+    data.update(overrides)
+    return data
+
+
+def _valid_contact_form_data(**overrides):
+    data = {
+        'name': 'John Smith',
+        'email': 'john@example.com',
+        'subject': 'Question about pricing',
+        'message': 'Hi, what do you charge for cleanup?',
+    }
+    data.update(overrides)
+    return data
+
+
+def _valid_quote_form_data(**overrides):
+    data = {
+        'first_name': 'Sam',
+        'last_name': 'Rivera',
+        'email': 'sam@example.com',
+        'phone': '555-0199',
+        'address': '123 Main St, Houston',
+        'date': '2026-06-01',
+        'service': 'Landscape Design',
+        'message': 'Need a quote on landscape design.',
+    }
+    data.update(overrides)
+    return data
+
+
+class HomeQuickFormTests(TestCase):
+    def test_valid_submission_creates_lead_with_split_name(self):
+        form = HomeQuickForm(data=_valid_quick_form_data())
+        self.assertTrue(form.is_valid(), form.errors)
+        lead = form.save()
+        self.assertEqual(lead.first_name, 'Jane')
+        self.assertEqual(lead.last_name, 'Doe')
+        self.assertEqual(lead.email, 'jane@example.com')
+        self.assertEqual(lead.service, 'Lawn & Garden Care')
+
+    def test_single_word_name_becomes_first_with_empty_last(self):
+        form = HomeQuickForm(data=_valid_quick_form_data(name='Cher'))
+        self.assertTrue(form.is_valid(), form.errors)
+        lead = form.save()
+        self.assertEqual(lead.first_name, 'Cher')
+        self.assertEqual(lead.last_name, '')
+
+    def test_three_word_name_splits_at_first_space(self):
+        form = HomeQuickForm(data=_valid_quick_form_data(name='Jane Q Doe'))
+        self.assertTrue(form.is_valid())
+        lead = form.save()
+        self.assertEqual(lead.first_name, 'Jane')
+        self.assertEqual(lead.last_name, 'Q Doe')
+
+    def test_honeypot_rejects(self):
+        form = HomeQuickForm(data=_valid_quick_form_data(website='http://spam.example'))
+        self.assertFalse(form.is_valid())
+        self.assertIn('website', form.errors)
+        self.assertEqual(ClientLeads.objects.count(), 0)
+
+    def test_missing_required_field(self):
+        form = HomeQuickForm(data=_valid_quick_form_data(email=''))
+        self.assertFalse(form.is_valid())
+        self.assertIn('email', form.errors)
+
+    def test_invalid_email_format(self):
+        form = HomeQuickForm(data=_valid_quick_form_data(email='not-an-email'))
+        self.assertFalse(form.is_valid())
+        self.assertIn('email', form.errors)
+
+
+class ContactFormTests(TestCase):
+    def test_valid_submission(self):
+        form = ContactForm(data=_valid_contact_form_data())
+        self.assertTrue(form.is_valid(), form.errors)
+        lead = form.save()
+        self.assertEqual(lead.first_name, 'John')
+        self.assertEqual(lead.last_name, 'Smith')
+        self.assertEqual(lead.subject, 'Question about pricing')
+
+    def test_honeypot_rejects(self):
+        form = ContactForm(data=_valid_contact_form_data(website='x'))
+        self.assertFalse(form.is_valid())
+
+
+class FreeQuoteFormTests(TestCase):
+    def test_valid_submission(self):
+        form = FreeQuoteForm(data=_valid_quote_form_data())
+        self.assertTrue(form.is_valid(), form.errors)
+        lead = form.save()
+        self.assertEqual(lead.first_name, 'Sam')
+        self.assertEqual(lead.last_name, 'Rivera')
+        self.assertEqual(lead.address, '123 Main St, Houston')
+
+    def test_missing_first_name(self):
+        form = FreeQuoteForm(data=_valid_quote_form_data(first_name=''))
+        self.assertFalse(form.is_valid())
+        self.assertIn('first_name', form.errors)
+
+    def test_honeypot_rejects(self):
+        form = FreeQuoteForm(data=_valid_quote_form_data(website='x'))
+        self.assertFalse(form.is_valid())

--- a/web_app/tests/test_views.py
+++ b/web_app/tests/test_views.py
@@ -1,10 +1,18 @@
 """Integration tests for the three lead-capture views."""
 
 from django.core import mail
+from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
 
 from web_app.models import ClientLeads
+
+
+class LeadViewTestCase(TestCase):
+    """Base: clears the process-wide rate-limit cache before each test."""
+
+    def setUp(self):
+        cache.clear()
 
 
 def _quick_data(**overrides):
@@ -45,7 +53,7 @@ def _quote_data(**overrides):
     return data
 
 
-class HomeViewTests(TestCase):
+class HomeViewTests(LeadViewTestCase):
     def test_get_returns_200(self):
         response = self.client.get(reverse('home'))
         self.assertEqual(response.status_code, 200)
@@ -84,7 +92,7 @@ class HomeViewTests(TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
 
-class ContactViewTests(TestCase):
+class ContactViewTests(LeadViewTestCase):
     def test_get_returns_200(self):
         response = self.client.get(reverse('contact'))
         self.assertEqual(response.status_code, 200)
@@ -103,7 +111,7 @@ class ContactViewTests(TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
 
-class FreeQuoteViewTests(TestCase):
+class FreeQuoteViewTests(LeadViewTestCase):
     def test_get_returns_200(self):
         response = self.client.get(reverse('free_quote'))
         self.assertEqual(response.status_code, 200)
@@ -121,7 +129,37 @@ class FreeQuoteViewTests(TestCase):
         self.assertEqual(len(mail.outbox), 0)
 
 
-class EmailFailureProtectsLeadTests(TestCase):
+class RateLimitTests(LeadViewTestCase):
+    """Per-IP rate limit on lead POSTs.
+
+    LocMemCache is per-process; tearing down between tests is handled
+    by clearing the cache in setUp.
+    """
+
+    def setUp(self):
+        from django.core.cache import cache
+        cache.clear()
+
+    def test_sixth_post_in_a_window_is_blocked(self):
+        # First 5 valid POSTs succeed.
+        for i in range(5):
+            response = self.client.post(reverse('home'), data=_quick_data(email=f'jane{i}@example.com'))
+            self.assertEqual(response.status_code, 200, f'POST #{i + 1} failed')
+
+        # 6th is blocked with 429.
+        response = self.client.post(reverse('home'), data=_quick_data(email='spam@example.com'))
+        self.assertEqual(response.status_code, 429)
+        # The 6th submission must NOT have created a lead or sent mail.
+        self.assertEqual(ClientLeads.objects.count(), 5)
+
+    def test_rate_limit_does_not_block_get(self):
+        # GET is not POST-method-rate-limited; should always serve.
+        for _ in range(10):
+            response = self.client.get(reverse('home'))
+            self.assertEqual(response.status_code, 200)
+
+
+class EmailFailureProtectsLeadTests(LeadViewTestCase):
     """If Resend (or any send_mail call) explodes, the ClientLead must persist.
 
     Patches ``send_lead_notification`` to raise; verifies the lead row is

--- a/web_app/tests/test_views.py
+++ b/web_app/tests/test_views.py
@@ -1,0 +1,136 @@
+"""Integration tests for the three lead-capture views."""
+
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+from web_app.models import ClientLeads
+
+
+def _quick_data(**overrides):
+    data = {
+        'name': 'Jane Doe',
+        'email': 'jane@example.com',
+        'phone': '555-0100',
+        'service': 'Lawn & Garden Care',
+        'message': 'Please come look at my lawn.',
+    }
+    data.update(overrides)
+    return data
+
+
+def _contact_data(**overrides):
+    data = {
+        'name': 'John Smith',
+        'email': 'john@example.com',
+        'subject': 'Question about pricing',
+        'message': 'Hi, what do you charge for cleanup?',
+    }
+    data.update(overrides)
+    return data
+
+
+def _quote_data(**overrides):
+    data = {
+        'first_name': 'Sam',
+        'last_name': 'Rivera',
+        'email': 'sam@example.com',
+        'phone': '555-0199',
+        'address': '123 Main St, Houston',
+        'date': '2026-06-01',
+        'service': 'Landscape Design',
+        'message': 'Need a quote on landscape design.',
+    }
+    data.update(overrides)
+    return data
+
+
+class HomeViewTests(TestCase):
+    def test_get_returns_200(self):
+        response = self.client.get(reverse('home'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_valid_post_creates_lead_and_sends_two_emails(self):
+        response = self.client.post(reverse('home'), data=_quick_data())
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'web_app/thank_you.html')
+
+        self.assertEqual(ClientLeads.objects.count(), 1)
+        lead = ClientLeads.objects.get()
+        self.assertEqual(lead.first_name, 'Jane')
+        self.assertEqual(lead.last_name, 'Doe')
+
+        self.assertEqual(len(mail.outbox), 2)
+        notif, autoreply = mail.outbox
+        self.assertIn('[Quick Estimate]', notif.subject)
+        self.assertEqual(notif.to, ['info@torresyardworks.com'])
+        self.assertEqual(notif.reply_to, ['jane@example.com'])
+        self.assertIn('Thanks for contacting', autoreply.subject)
+        self.assertEqual(autoreply.to, ['jane@example.com'])
+        self.assertEqual(autoreply.reply_to, ['info@torresyardworks.com'])
+
+    def test_invalid_post_renders_index_with_no_email(self):
+        response = self.client.post(reverse('home'), data=_quick_data(email='bad'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'web_app/index.html')
+        self.assertEqual(ClientLeads.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_honeypot_rejects_silently_to_user(self):
+        response = self.client.post(reverse('home'), data=_quick_data(website='spam'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'web_app/index.html')
+        self.assertEqual(ClientLeads.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class ContactViewTests(TestCase):
+    def test_get_returns_200(self):
+        response = self.client.get(reverse('contact'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_valid_post_creates_lead_and_sends_two_emails(self):
+        response = self.client.post(reverse('contact'), data=_contact_data())
+        self.assertTemplateUsed(response, 'web_app/thank_you.html')
+
+        self.assertEqual(ClientLeads.objects.count(), 1)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertIn('[Contact]', mail.outbox[0].subject)
+
+    def test_invalid_post_renders_contact(self):
+        response = self.client.post(reverse('contact'), data=_contact_data(email=''))
+        self.assertTemplateUsed(response, 'web_app/contact.html')
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class FreeQuoteViewTests(TestCase):
+    def test_get_returns_200(self):
+        response = self.client.get(reverse('free_quote'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_valid_post_creates_lead_and_sends_two_emails(self):
+        response = self.client.post(reverse('free_quote'), data=_quote_data())
+        self.assertTemplateUsed(response, 'web_app/thank_you.html')
+        self.assertEqual(ClientLeads.objects.count(), 1)
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertIn('[Free Quote]', mail.outbox[0].subject)
+
+    def test_invalid_post_renders_quote_form(self):
+        response = self.client.post(reverse('free_quote'), data=_quote_data(first_name=''))
+        self.assertTemplateUsed(response, 'web_app/request_quote.html')
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class EmailFailureProtectsLeadTests(TestCase):
+    """If Resend (or any send_mail call) explodes, the ClientLead must persist.
+
+    Patches ``send_lead_notification`` to raise; verifies the lead row is
+    still created and the request still returns 200.
+    """
+
+    def test_notification_send_failure_does_not_lose_lead(self):
+        from unittest.mock import patch
+        with patch('web_app.views.send_lead_notification', side_effect=RuntimeError('Resend down')):
+            response = self.client.post(reverse('home'), data=_quick_data())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ClientLeads.objects.count(), 1)

--- a/web_app/views.py
+++ b/web_app/views.py
@@ -1,8 +1,48 @@
+import logging
+
 from django.db import connection
 from django.http import JsonResponse
 from django.shortcuts import render
-from django.core.mail import send_mail
-from .models import HeroSlide, Event, ClientLeads, GalleryUpload, Testimonies
+from django.views.decorators.http import require_http_methods
+
+from .emails import send_lead_autoreply, send_lead_notification
+from .forms import ContactForm, FreeQuoteForm, HomeQuickForm
+from .models import Event, GalleryUpload, HeroSlide, Testimonies
+
+logger = logging.getLogger(__name__)
+
+
+def _client_ip(request) -> str:
+    """Extract the originating client IP, honoring X-Forwarded-For from Caddy."""
+    xff = request.META.get('HTTP_X_FORWARDED_FOR', '')
+    if xff:
+        return xff.split(',')[0].strip()
+    return request.META.get('REMOTE_ADDR', '')
+
+
+def _handle_lead_post(request, form, *, form_name: str):
+    """Save the lead, fire both emails, return the rendered thank-you page.
+
+    Email failures are logged but do NOT roll back the lead — the row in
+    ``ClientLeads`` is the source of truth; the email is a convenience
+    notification. The owner can always recover the lead via the admin
+    export (`django-import-export`).
+    """
+    lead = form.save()
+    try:
+        send_lead_notification(lead, form_name=form_name)
+    except Exception:  # noqa: BLE001 — we deliberately swallow to protect lead persistence
+        logger.exception("Failed to send lead notification for ClientLeads #%s", lead.pk)
+    try:
+        send_lead_autoreply(lead, form_name=form_name)
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to send autoreply for ClientLeads #%s", lead.pk)
+    return render(request, 'web_app/thank_you.html', {'first_name': lead.first_name})
+
+
+# ---------------------------------------------------------------------------
+# Public pages
+# ---------------------------------------------------------------------------
 
 
 def health_check(request):
@@ -11,37 +51,21 @@ def health_check(request):
     return JsonResponse({"status": "ok"})
 
 
-
-# Home page.
-
-
+@require_http_methods(["GET", "POST"])
 def home(request):
-    slide = HeroSlide.objects.all()
-    event = Event.objects.all()
-    testimony = Testimonies.objects.all()
-    if request.method=="POST":
-        first_name = request.POST['name']
-        email = request.POST['email']
-        phone = request.POST['phone']
-        service = request.POST['service']
-        message = request.POST['message']
-        ins = ClientLeads(first_name=first_name,email=email,phone=phone,service=service,message=message)
-        ins.save()
-
-        msg_mail = "Name: " + str(first_name) + "\n\nEmail: " + str(email) + "\n\nPhone: " + str(phone) + "\n\nService: " + str(service) + "\n\nMessage: " + str(message)
-        # Send Email
-        send_mail(
-            'Torres Small Request Form by: ' + first_name,  # subject
-            msg_mail,
-            email,
-            ['torresyardworks@gmail.com'],  # to email
-            fail_silently=False,
-        )
-        print("Data has been written in db.")
-        return render(request, 'web_app/thank_you.html', {'first_name': first_name})
+    if request.method == "POST":
+        form = HomeQuickForm(data=request.POST, remote_ip=_client_ip(request))
+        if form.is_valid():
+            return _handle_lead_post(request, form, form_name='Quick Estimate')
     else:
-        return render(request, 'web_app/index.html', {'slides': slide, 'events': event, 'testimonys': testimony})
+        form = HomeQuickForm(remote_ip=_client_ip(request))
 
+    return render(request, 'web_app/index.html', {
+        'slides': HeroSlide.objects.all(),
+        'events': Event.objects.all(),
+        'testimonys': Testimonies.objects.all(),
+        'form': form,
+    })
 
 
 def about(request):
@@ -69,64 +93,36 @@ def indoor(request):
 
 
 def gallery(request):
-    photo = GalleryUpload.objects.all()
-    return render(request, 'web_app/gallery.html', {'photos': photo})
+    return render(request, 'web_app/gallery.html', {'photos': GalleryUpload.objects.all()})
 
 
+@require_http_methods(["GET", "POST"])
 def contact(request):
-    if request.method=="POST":
-        first_name = request.POST['name']
-        email = request.POST['email']
-        subject = request.POST['subject']
-        message = request.POST['message']
-        ins = ClientLeads(first_name=first_name,email=email,subject=subject,message=message)
-        ins.save()
-
-        msg_mail = "Name: " + str(first_name) + "\n\nEmail: " + str(email) + "\n\nSubject: " + str(subject) + "\n\nMessage: " + str(message)
-        # Send Email
-        send_mail(
-            'Torres Contact Form by: ' + first_name,  # subject
-            msg_mail,
-            email,
-            ['torresyardworks@gmail.com'],  # to email
-            fail_silently=False,
-        )
-        print("Data has been written in db.")
-        return render(request, 'web_app/thank_you.html', {'first_name': first_name})
+    if request.method == "POST":
+        form = ContactForm(data=request.POST, remote_ip=_client_ip(request))
+        if form.is_valid():
+            return _handle_lead_post(request, form, form_name='Contact')
     else:
-        return render(request, 'web_app/contact.html', {})
-    
+        form = ContactForm(remote_ip=_client_ip(request))
 
+    return render(request, 'web_app/contact.html', {'form': form})
+
+
+@require_http_methods(["GET", "POST"])
 def free_quote(request):
-    if request.method=="POST":
-        first_name = request.POST['first_name']
-        last_name = request.POST['last_name']
-        email = request.POST['email']
-        phone = request.POST['phone']
-        address = request.POST['address']
-        date = request.POST['date']
-        service = request.POST['service']
-        message = request.POST['message']
-        ins = ClientLeads(first_name=first_name,last_name=last_name,email=email,phone=phone,address=address,date=date,service=service,message=message)
-        ins.save()
-
-        msg_mail = "Name: " + str(first_name) + " " + str(last_name) + "\n\nEmail: " + str(email) + "\n\nPhone: " + str(phone) + "\n\nAddress: " + str(address) + "\n\nDate: " + str(date) + "\n\nService: " + str(service) + "\n\nMessage: " + str(message)
-        # Send Email
-        send_mail(
-            'Torres Request Form by: ' + first_name + " " + last_name,  # subject
-            msg_mail,
-            email,
-            ['torresyardworks@gmail.com'],  # to email
-            fail_silently=False,
-        )
-        print("Data has been written in db.")
-        return render(request, 'web_app/thank_you.html', {'first_name': first_name})
+    if request.method == "POST":
+        form = FreeQuoteForm(data=request.POST, remote_ip=_client_ip(request))
+        if form.is_valid():
+            return _handle_lead_post(request, form, form_name='Free Quote')
     else:
-        return render(request, 'web_app/request_quote.html', {})
+        form = FreeQuoteForm(remote_ip=_client_ip(request))
+
+    return render(request, 'web_app/request_quote.html', {'form': form})
 
 
 def thank_you(request):
     return render(request, 'web_app/thank_you.html', {})
+
 
 # Test page for models and forms
 def test(request):

--- a/web_app/views.py
+++ b/web_app/views.py
@@ -1,13 +1,34 @@
 import logging
 
+from functools import wraps
+
 from django.db import connection
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
+from django_ratelimit.decorators import ratelimit
 
 from .emails import send_lead_autoreply, send_lead_notification
 from .forms import ContactForm, FreeQuoteForm, HomeQuickForm
 from .models import Event, GalleryUpload, HeroSlide, Testimonies
+
+# Per-IP rate cap on lead-form POSTs. Counters live in LocMemCache (see
+# settings.CACHES). We layer this on top of ratelimit(block=False) so we
+# can return a proper 429 — block=True would raise Ratelimited (a
+# PermissionDenied subclass) which Django renders as 403.
+LEAD_RATE = '5/h'
+
+
+def _rate_limited_response(view_func):
+    """Return 429 when @ratelimit(block=False) has flagged request.limited."""
+
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        if getattr(request, 'limited', False):
+            return render(request, 'web_app/rate_limited.html', status=429)
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +72,12 @@ def health_check(request):
     return JsonResponse({"status": "ok"})
 
 
+
+
+
 @require_http_methods(["GET", "POST"])
+@ratelimit(key='ip', rate=LEAD_RATE, method='POST', block=False)
+@_rate_limited_response
 def home(request):
     if request.method == "POST":
         form = HomeQuickForm(data=request.POST, remote_ip=_client_ip(request))
@@ -97,6 +123,8 @@ def gallery(request):
 
 
 @require_http_methods(["GET", "POST"])
+@ratelimit(key='ip', rate=LEAD_RATE, method='POST', block=False)
+@_rate_limited_response
 def contact(request):
     if request.method == "POST":
         form = ContactForm(data=request.POST, remote_ip=_client_ip(request))
@@ -109,6 +137,8 @@ def contact(request):
 
 
 @require_http_methods(["GET", "POST"])
+@ratelimit(key='ip', rate=LEAD_RATE, method='POST', block=False)
+@_rate_limited_response
 def free_quote(request):
     if request.method == "POST":
         form = FreeQuoteForm(data=request.POST, remote_ip=_client_ip(request))


### PR DESCRIPTION
## Summary

Phase 2 of the Torres Yardworks roadmap (email + spam slice). Fixes the
long-standing bug where lead forms passed the **customer's email** as
`from_email` to `send_mail()` — Gmail rejected it, so notifications
silently failed. Also routes the team inbox to a real Workspace user.

7 commits, 29/29 tests green.

### What changed

- **Sender pipeline**: Gmail SMTP → Resend HTTP API via `django-anymail`.
  Settings are env-driven; dev still uses `console.EmailBackend`. Resend
  domain (`torresyardworks.com`) verified with DKIM + dedicated
  Return-Path subdomain (`send.torresyardworks.com`) so the root SPF
  for Google Workspace stays untouched.
- **Lead emails**: two messages per submission.
  - `send_lead_notification` → owner inbox `info@torresyardworks.com`,
    Reply-To = customer (one-click reply lands at the customer).
  - `send_lead_autoreply` → customer inbox, Reply-To = team (customer
    replies land at the team). Multipart text + HTML.
- **Forms**: views rewritten onto a `LeadFormBase` ModelForm hierarchy
  (`HomeQuickForm`, `ContactForm`, `FreeQuoteForm`). The raw
  `request.POST.get` parsing is gone; validation now happens server-side
  in `clean_*` methods.
- **Spam protection (defense in depth)**:
  1. CSS-hidden `website` honeypot field.
  2. Cloudflare Turnstile (`django-turnstile`) — server-side siteverify
     in the form's `clean()`.
  3. `@ratelimit(key='ip', rate='5/h', method='POST')` returning a real
     429 + friendly page (not 403).
- **Displayed contact**: footer + contact-page sidebar now show
  `info@torresyardworks.com` instead of the old Gmail.
- **Lead persistence is protected**: each email send is wrapped in
  `try/except`. If Resend has an outage, the `ClientLeads` row still
  lands and the admin export remains the source of truth.

### Drive-by fix

`thank_you.html` linked unconditionally to `{% url 'gallery' %}`, but
that URL only exists when `DEBUG=True` (gallery is hidden in prod).
Wrapped the link in `{% if show_debug %}` like the other gallery refs.

### Tests

- `web_app/tests.py` stub → `tests/` package.
- `tests/__init__.py` flips Turnstile's `ENABLE` flag off so unit tests
  don't hit Cloudflare's siteverify endpoint.
- 5 email-helper tests, 11 form tests, 13 view integration tests
  including honeypot rejection, ESP-failure-protects-lead, and the 6th
  POST → 429 rate-limit trip.

### External setup status

- [x] Resend account created, domain verified (DKIM + send. CNAMEs live)
- [x] DNS records applied at Porkbun via MCP
- [x] Resend API key generated (Sending Access only)
- [ ] Cloudflare Turnstile widget — in flight
- [ ] Update droplet \`.env.prod\` with `RESEND_API_KEY`,
      `EMAIL_BACKEND=anymail.backends.resend.EmailBackend`,
      `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY` (before merge)

### Test plan after merge

- [ ] Resend dashboard shows two sends per submission, both delivered.
- [ ] `info@torresyardworks.com` receives notifications; clicking reply
      addresses the customer.
- [ ] A test customer address receives the autoreply; reply addresses
      the team.
- [ ] Turnstile dashboard shows challenge solves.
- [ ] mail-tester.com score ≥ 9/10 (verifies SPF + DKIM alignment).
- [ ] Submit a form with the honeypot filled (DevTools) → no email, no
      lead row.
- [ ] Send 6 POSTs from the same IP within an hour → 6th gets 429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)